### PR TITLE
Fix Update

### DIFF
--- a/lib/identity.js
+++ b/lib/identity.js
@@ -24,7 +24,9 @@ var Update = function(physicalId, params, oldParams, reply) {
       console.error(err);
       return reply(err);
     }
-    params.CallerReference = uuid.v4();
+    console.log("Found OAI: " + JSON.stringify(data));
+    // We must specify the existing CallerReference
+    params.CallerReference =   data.CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig.CallerReference;
     var p = {
       Id: physicalId,
       CloudFrontOriginAccessIdentityConfig: params,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-# deploy.sh
 
-# Configuration
-AWS_PROFILE="delichty"
-BUCKET="ourpts-common-ohio-454844014023"
-S3PATH="lambda"
-PACKAGE="aws-cloudformation-cloudfront-identity.zip"
+node_modules/.bin/cfn-lambda zip --output deploy/archive.zip
 
-echo "Biulding the package"
-#node_modules/.bin/cfn-lambda zip --output deploy/archive.zip
+echo "Deploy $TRAVIS_TAG version to S3"
+aws s3 cp deploy/archive.zip s3://chatanoo-deployment/aws-cloudformation-cloudfront-identity/$TRAVIS_TAG.zip
 
-echo "Deploy version to S3"
-aws --profile ${AWS_PROFILE} s3 cp deploy/archive.zip s3://${BUCKET}/${S3PATH}/${PACKAGE}
+echo "Upload latest"
+aws s3api put-object \
+  --bucket chatanoo-deployment \
+  --key aws-cloudformation-cloudfront-identity/latest.zip \
+  --website-redirect-location /chatanoo-deployment/aws-cloudformation-cloudfront-identity/$TRAVIS_TAG.zip

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
+# deploy.sh
 
-node_modules/.bin/cfn-lambda zip --output deploy/archive.zip
+# Configuration
+AWS_PROFILE="delichty"
+BUCKET="ourpts-common-ohio-454844014023"
+S3PATH="lambda"
+PACKAGE="aws-cloudformation-cloudfront-identity.zip"
 
-echo "Deploy $TRAVIS_TAG version to S3"
-aws s3 cp deploy/archive.zip s3://chatanoo-deployment/aws-cloudformation-cloudfront-identity/$TRAVIS_TAG.zip
+echo "Biulding the package"
+#node_modules/.bin/cfn-lambda zip --output deploy/archive.zip
 
-echo "Upload latest"
-aws s3api put-object \
-  --bucket chatanoo-deployment \
-  --key aws-cloudformation-cloudfront-identity/latest.zip \
-  --website-redirect-location /chatanoo-deployment/aws-cloudformation-cloudfront-identity/$TRAVIS_TAG.zip
+echo "Deploy version to S3"
+aws --profile ${AWS_PROFILE} s3 cp deploy/archive.zip s3://${BUCKET}/${S3PATH}/${PACKAGE}


### PR DESCRIPTION
The CallerReference cannot be changed on an update. However, the CallerReference must be included in the request parameters. This minor change pulls the current value of CallerReference and iuses that value in the parameters for the update.

This has been tested and verified that it works, allowing updates to the OAI resource.